### PR TITLE
discard sources order in favor of imported names

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -39,7 +39,10 @@
     "object-literal-sort-keys": false,
     "one-variable-per-declaration": false,
     "only-arrow-functions": false,
-    "ordered-imports": true,
+    "ordered-imports": [true, {
+      "import-sources-order": "any",
+      "named-imports-order": "case-insensitive"
+    }],
     "prefer-const": true,
     "prefer-for-of": false,
     "quotemark": [ true, "single", "avoid-escape", "avoid-template" ],


### PR DESCRIPTION
When importing, now tslint will only care about the names of the imports and wouldn't sweat about the paths of the imports.

Also, I could not find a way to enforce the following order:
```
import 'global-module'
import defaultExport from 'path'
import { namedExport } from 'path'
```
However we can silence Tslint from complaining about this simply adding spaces between imports:
```
import 'global-module'

import defaultExport from 'path'

import { namedExport } from 'path'
```

**So let us enforce this in reviews**