### PR TITLE
Semicolon rule update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+*1.0.10*
+> Fix: removed "no-semicolon-interface" and add extra options to semicolon  
+
 *1.0.9*
 > Fix: extend tslint-divid package
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invisible/tslint-config",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Invisible's TSLint rules",
   "main": "tslint.json",
   "repository": "git@github.com:invisible-tech/tslint-config.git",

--- a/tslint.json
+++ b/tslint.json
@@ -32,7 +32,7 @@
     "no-default-export": true,
     "no-empty": true,
     "no-implicit-dependencies": [ false ],
-    "semicolon": [true, "never", "ignore-interfaces"],
+    "semicolon": [true, "never"],
     "no-submodule-imports": [ false ],
     "no-trailing-whitespace": true,
     "no-unnecessary-initializer": true,

--- a/tslint.json
+++ b/tslint.json
@@ -32,7 +32,7 @@
     "no-default-export": true,
     "no-empty": true,
     "no-implicit-dependencies": [ false ],
-    "no-semicolon-interface": true,
+    "semicolon": [true, "never", "ignore-interfaces"],
     "no-submodule-imports": [ false ],
     "no-trailing-whitespace": true,
     "no-unnecessary-initializer": true,
@@ -46,7 +46,6 @@
     "prefer-const": true,
     "prefer-for-of": false,
     "quotemark": [ true, "single", "avoid-escape", "avoid-template" ],
-    "semicolon": { "options": [ "never" ] },
     "space-before-function-paren": [ true, "always" ],
     "trailing-comma": [true, {"multiline": "always", "singleline": "never"}]   ,
     "variable-name": [true, "ban-keywords", "check-format", "allow-leading-underscore", "allow-pascal-case"]


### PR DESCRIPTION
Rule updated according to this >> https://palantir.github.io/tslint/rules/semicolon/

was having an error when doing tslint --fix: 

> Could not find implementations for the following rules specified in the configuration:
>     no-semicolon-interface
> Try upgrading TSLint and/or ensuring that you have all necessary custom rules installed.
> If TSLint was recently upgraded, you may have old rules configured which need to be cleaned up.